### PR TITLE
Make the mod compatible with 1.19 minor versions

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.14.0",
     "fabric": "*",
-    "minecraft": "1.19",
+    "minecraft": "~1.19",
     "java": ">=17"
   },
   "recommends": {


### PR DESCRIPTION
The 1.19 version of the mod currently only works with 1.19, and not with 1.19.1 or 1.19.2. This PR fixes that.