### PR TITLE
Improve compact chat performance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Chat Patches `201.5.6` for Minecraft 1.20, 1.20.1 on Fabric, Quilt
+- Improve performance when using compact chat.
+
 ## Chat Patches `201.5.5` for Minecraft 1.20, 1.20.1 on Fabric, Quilt
 - YACL images now load without crashing the game! Enjoy preview images right from the get-go!
 - Fixed [#108](https://www.github.com/mrbuilder1961/ChatPatches/issues/108), thanks [replaceitem](https://github.com/replaceitem)!

--- a/src/main/java/obro1961/chatpatches/util/ChatUtils.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtils.java
@@ -99,7 +99,9 @@ public class ChatUtils {
 				.stream()
 				.map( visible -> StringTextUtils.reorder(visible, false) )
 				.toList();
-			visibleMessages.removeIf(hudLine -> calcVisibles.stream().anyMatch(ot -> ot.equalsIgnoreCase( StringTextUtils.reorder(hudLine.content(), false) )));
+			if (config.counterCompact) {
+				visibleMessages.removeIf(hudLine -> calcVisibles.stream().anyMatch(ot -> ot.equalsIgnoreCase( StringTextUtils.reorder(hudLine.content(), false) )));
+			} else if (calcVisibles.get(0).equalsIgnoreCase(StringTextUtils.reorder(visibleMessages.get(0).content(), false))) visibleMessages.remove(0);
 
 			// same as {@code incoming} but with the appropriate transformations
 			return incomingParts.stream().map(Text::copy).reduce(MutableText.of( incoming.getContent() ), MutableText::append).setStyle( incoming.getStyle() );

--- a/src/main/java/obro1961/chatpatches/util/ChatUtils.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtils.java
@@ -101,7 +101,7 @@ public class ChatUtils {
 				.toList();
 			if (config.counterCompact) {
 				visibleMessages.removeIf(hudLine -> calcVisibles.stream().anyMatch(ot -> ot.equalsIgnoreCase( StringTextUtils.reorder(hudLine.content(), false) )));
-			} else if (calcVisibles.get(0).equalsIgnoreCase(StringTextUtils.reorder(visibleMessages.get(0).content(), false))) visibleMessages.remove(0);
+			} else if (!calcVisibles.isEmpty() && !visibleMessages.isEmpty() && calcVisibles.get(0).equalsIgnoreCase(StringTextUtils.reorder(visibleMessages.get(0).content(), false))) visibleMessages.remove(0);
 
 			// same as {@code incoming} but with the appropriate transformations
 			return incomingParts.stream().map(Text::copy).reduce(MutableText.of( incoming.getContent() ), MutableText::append).setStyle( incoming.getStyle() );


### PR DESCRIPTION
Improves the performance when using compactChat (without the CompactChat toggle). The benefits may not be noticeable with default settings, but at high chatHistory values it makes a huge difference. This is done by only checking the last message against a new message instead of checking ALL visible messages against ALL newly visible messages (for 16k visible messages thats a lot of comparisons). Also improves world joining speed when first joining a world after launching the game, as this causes all messages to be evalated again.