### PR TITLE
Simplify compact chat logic and bug fix

### DIFF
--- a/src/main/java/obro1961/chatpatches/util/ChatUtils.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtils.java
@@ -101,7 +101,10 @@ public class ChatUtils {
 				.toList();
 			if (config.counterCompact) {
 				visibleMessages.removeIf(hudLine -> calcVisibles.stream().anyMatch(ot -> ot.equalsIgnoreCase( StringTextUtils.reorder(hudLine.content(), false) )));
-			} else if (!calcVisibles.isEmpty() && !visibleMessages.isEmpty() && calcVisibles.get(0).equalsIgnoreCase(StringTextUtils.reorder(visibleMessages.get(0).content(), false))) visibleMessages.remove(0);
+			} else {
+				visibleMessages.remove(0);
+				while(!visibleMessages.isEmpty() && !visibleMessages.get(0).endOfEntry()) visibleMessages.remove(0);
+			}
 
 			// same as {@code incoming} but with the appropriate transformations
 			return incomingParts.stream().map(Text::copy).reduce(MutableText.of( incoming.getContent() ), MutableText::append).setStyle( incoming.getStyle() );


### PR DESCRIPTION
So I noticed there was this issue when sometimes messages would be detected as duplicate (it would show the duplicate counter in the chat) but the old message wasn't deleted. This can occur when a message is multiline in the chat, in which case the equalsignorecase does not work properly. This did not affect the previous method of checking all visiblemessages against all calculated messages but does affect only checking the first element. The fix is to always delete the first displayed message, because further up in the file there was already a check if the new and previous messages are equal. The while loop is necessary to correctly delete multiline messages.