### PR TITLE
Add delay to showing completion while typing

### DIFF
--- a/src/main/java/obro1961/chatpatches/config/Config.java
+++ b/src/main/java/obro1961/chatpatches/config/Config.java
@@ -46,7 +46,7 @@ public class Config {
     public boolean boundary = true; public String boundaryFormat = "&8[&r$&8]"; public int boundaryColor = 0x55ffff;
     public boolean chatlog = true; public int chatlogSaveInterval = 0;
     public boolean chatHidePacket = true; public int chatWidth = 0, chatMaxMessages = 16384; public String chatNameFormat = "<$>"; public int chatNameColor = 0xffffff;
-    public int shiftChat = 10; public boolean messageDrafting = false, onlyInvasiveDrafting = false, searchDrafting = true, hideSearchButton = false, vanillaClearing = false, searchPrefix = false;
+    public int shiftChat = 10, completionDelay = 0; public boolean messageDrafting = false, onlyInvasiveDrafting = false, searchDrafting = true, hideSearchButton = false, vanillaClearing = false, searchPrefix = false;
     public int copyColor = 0x55ffff; public String copyReplyFormat = "/msg $ ";
 
     /**

--- a/src/main/java/obro1961/chatpatches/config/YACLConfig.java
+++ b/src/main/java/obro1961/chatpatches/config/YACLConfig.java
@@ -253,7 +253,7 @@ public class YACLConfig extends Config {
         if(min) {
             return switch(key) {
                 case "counterCompactDistance" -> -1;
-                default -> 0; // chatWidth, chatMaxMessages, shiftChat, chatlogSaveInterval
+                default -> 0; // chatWidth, chatMaxMessages, shiftChat, chatlogSaveInterval, completionDelay
             };
         } else {
             return switch(key) {
@@ -263,6 +263,7 @@ public class YACLConfig extends Config {
                 // only issue w ^^^ is if the window is resized while the config screen is open the max value will be incorrect
                 // other issue could be with the future config redo, as annotation constraints must be *constant*
                 case "chatMaxMessages" -> Short.MAX_VALUE;
+                case "completionDelay" -> 5000;
                 default -> 100; // shiftChat
             };
         }

--- a/src/main/resources/assets/chatpatches/lang/en_us.json
+++ b/src/main/resources/assets/chatpatches/lang/en_us.json
@@ -96,6 +96,7 @@
     "text.chatpatches.hideSearchButton": "Hide search button",
     "text.chatpatches.vanillaClearing": "Vanilla chat clearing",
     "text.chatpatches.searchPrefix": "Search prefix",
+    "text.chatpatches.completionDelay": "Typing completion delay",
     "text.chatpatches.desc.chatHidePacket": "Should hide message packets that delete chat messages be ignored?",
     "text.chatpatches.desc.chatWidth": "The width of the chat box. This overrides vanilla's default and allows for a much larger width. Set to 0 to use the vanilla setting and not override it.",
     "text.chatpatches.desc.chatMaxMessages": "The max amount of chat messages allowed to save. Vanilla caps it at 100, this mod can increase it up to 32,767. Keep in mind a higher max equals higher memory usage.",
@@ -108,6 +109,7 @@
     "text.chatpatches.desc.hideSearchButton": "Should the search button be hidden? Note that this disables all search functionality.",
     "text.chatpatches.desc.vanillaClearing": "Should chat messages clear after leaving a world/server like vanilla? Note this completely erases both the chat and chat log.",
     "text.chatpatches.desc.searchPrefix": "Should the chat field have the history with the same prefix before cursor when pressing up/down arrow key? Vanilla uses the immediate history.",
+    "text.chatpatches.desc.completionDelay": "The delay length in milliseconds before showing completions while typing. Set to 0 to use the vanilla behavior.",
 
     "text.chatpatches.help.dateFormat": "For date and time formatting information, click me!",
     "text.chatpatches.help.formatCodes": "For formatting code characters and which ones do what, click me!",

--- a/src/main/resources/assets/chatpatches/lang/zh_cn.json
+++ b/src/main/resources/assets/chatpatches/lang/zh_cn.json
@@ -72,6 +72,7 @@
     "text.chatpatches.hideSearchButton": "隐藏搜索按钮",
     "text.chatpatches.vanillaClearing": "原版聊天清除",
     "text.chatpatches.searchPrefix": "搜索前缀",
+    "text.chatpatches.completionDelay": "输入补全延迟",
     "text.chatpatches.desc.chatLog": "是否保存聊天记录，以便在另一个游戏会话中重新添加到聊天中？",
     "text.chatpatches.desc.chatWidth": "聊天框的宽度。这将覆盖原版的默认设置，允许更大的宽度。设置为0以使用原版设置而不进行覆盖。",
     "text.chatpatches.desc.chatMaxMessages": "允许保存的最大聊天消息数量。原版限制为100，这个模组可以增加到32767。请记住，更高的最大值意味着更高的内存使用。",
@@ -82,6 +83,7 @@
     "text.chatpatches.desc.hideSearchButton": "是否隐藏搜索按钮？注意，这将禁用所有搜索功能。",
     "text.chatpatches.desc.vanillaClearing": "是否像原版那样在离开一个世界/服务器后清除聊天消息？注意，这将完全清除聊天和聊天记录。",
     "text.chatpatches.desc.searchPrefix": "是否在按了上或下按键后，将聊天框内文字设为前缀和光标前的字符相同的聊天记录？原版会设为相邻的消息。",
+    "text.chatpatches.desc.completionDelay": "输入时显示自动补全的延迟毫秒数。设置为0以使用原版行为。",
 
     "text.chatpatches.copyReplyFormat": "回复文本格式",
     "text.chatpatches.copyColor": "消息选择颜色",


### PR DESCRIPTION
Mimics the delay behavior of coding IDEs. Usually people wants immediate completions, but there are also reasons to make them slower: neat UI, less distractions.
It also synergies with #154 to prevent the completion from occupying up/down arrow keys.