### PR TITLE
Adjust ChatLog MessageIndicator for consistency with the base game

### DIFF
--- a/src/main/java/obro1961/chatpatches/chatlog/ChatLog.java
+++ b/src/main/java/obro1961/chatpatches/chatlog/ChatLog.java
@@ -41,7 +41,7 @@ import static obro1961.chatpatches.ChatPatches.config;
 public class ChatLog {
     public static final Path PATH = FabricLoader.getInstance().getGameDir().resolve("logs").resolve("chatlog.json");
     public static final Text RESTORED_TEXT = Text.translatable("text.chatpatches.restored");
-    public static final MessageIndicator INDICATOR_RESTORED = new MessageIndicator(0x382fb5, null, RESTORED_TEXT, "Restored");
+    public static final MessageIndicator RESTORED_INDICATOR = new MessageIndicator(0x382fb5, null, RESTORED_TEXT, "Restored");
 
     private static final MinecraftClient mc = MinecraftClient.getInstance();
 
@@ -276,7 +276,7 @@ public class ChatLog {
             data.history.forEach(mc.inGameHud.getChatHud()::addToMessageHistory);
 
         if(!data.messages.isEmpty())
-            data.messages.forEach(msg -> mc.inGameHud.getChatHud().addMessage(msg, null, INDICATOR_RESTORED));
+            data.messages.forEach(msg -> mc.inGameHud.getChatHud().addMessage(msg, null, RESTORED_INDICATOR));
 
         suspended = false;
 

--- a/src/main/java/obro1961/chatpatches/chatlog/ChatLog.java
+++ b/src/main/java/obro1961/chatpatches/chatlog/ChatLog.java
@@ -12,7 +12,6 @@ import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.registry.RegistryOps;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextCodecs;
@@ -41,7 +40,8 @@ import static obro1961.chatpatches.ChatPatches.config;
  */
 public class ChatLog {
     public static final Path PATH = FabricLoader.getInstance().getGameDir().resolve("logs").resolve("chatlog.json");
-    public static final MessageIndicator RESTORED_TEXT = new MessageIndicator(0x382fb5, null, null, I18n.translate("text.chatpatches.restored"));
+    public static final Text RESTORED_TEXT = Text.translatable("text.chatpatches.restored");
+    public static final MessageIndicator INDICATOR_RESTORED = new MessageIndicator(0x382fb5, null, RESTORED_TEXT, "Restored");
 
     private static final MinecraftClient mc = MinecraftClient.getInstance();
 
@@ -276,7 +276,7 @@ public class ChatLog {
             data.history.forEach(mc.inGameHud.getChatHud()::addToMessageHistory);
 
         if(!data.messages.isEmpty())
-            data.messages.forEach(msg -> mc.inGameHud.getChatHud().addMessage(msg, null, RESTORED_TEXT));
+            data.messages.forEach(msg -> mc.inGameHud.getChatHud().addMessage(msg, null, INDICATOR_RESTORED));
 
         suspended = false;
 


### PR DESCRIPTION
This PR makes a simple change to the `MessageIndicator` used by the `ChatLog` class, to improve consistency when identifying chat messages based on the indicator.

In the base game, a translatable text object is passed as the 3rd parameter of the `MessageIndicator` constructor, and a hard-coded string is passed as the 4th parameter.

Currently, ChatPatches passes a translated string as the 4th parameter, preventing other mods from using that string to identify messages.

Modifying the `MessageIndicator` to be consistent with the base game will allow other mods to correctly identify messages added by `ChatLog` when processing chat.