### PR TITLE
Chat Heads compat

### DIFF
--- a/src/main/java/obro1961/chatpatches/config/Config.java
+++ b/src/main/java/obro1961/chatpatches/config/Config.java
@@ -198,7 +198,7 @@ public class Config {
      * player entity and have both a valid name and UUID. Additionally,
      * the {@linkplain Minecraft#level client world} must exist.
      */
-    public MutableComponent formatPlayername(Component originalMessage, GameProfile profile) {
+    public MutableComponent formatPlayername(Optional<Component> head, GameProfile profile) {
         Style style = Style.EMPTY.withColor(nameColor); // defaults to the config-specified color
 		String name = profile != null ? profile./*? if >=1.21.9 {*/name/*?} else {*//*getName*//*?}*/() : "<null>";
 		var level = mc().level;
@@ -215,13 +215,9 @@ public class Config {
             components.add(text( configFormat[1] + " " )); // config suffix
 
 			/*? if >=1.21.9 {*/
-			if(/*ChatHeadsIntegration.*/installed() && usingBeforeName()) {
-				// if installed and necessary, gets the already-added head
-				// component from the message and adds it to the playername!
-				// see #285 (ChatHeads#83) for why it's easier for Chat Patches to do this going forward
-				var head = extractHeadComponent(originalMessage);
-				head.ifPresent(mutableComponent -> components.set(1, mutableComponent.append(components.get(1))));
-			}
+			// adds a pre-existing head from the message's <%s> part to the playername!
+			// see #285 (ChatHeads#83) for why it's easier for Chat Patches to do this going forward
+			head.ifPresent(component -> components.set(1, Component.empty().append(component).append(components.get(1))));
 			/*?}*/
 
             if(team != null) {

--- a/src/main/java/obro1961/chatpatches/integration/ChatHeadsIntegration.java
+++ b/src/main/java/obro1961/chatpatches/integration/ChatHeadsIntegration.java
@@ -4,7 +4,6 @@ package obro1961.chatpatches.integration;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.GuiMessageTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.contents.ObjectContents;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.network.chat.contents.objects.PlayerSprite;
@@ -83,22 +82,22 @@ public class ChatHeadsIntegration {
 	 * @return An {@link Optional} enclosing the component containing the head
 	 * object, or an empty Optional if
 	 *
-	 * @param message The chat message to look for a head component aka
-	 * {@link PlayerSprite} object in. This message must be unmodified by
-	 * Chat Patches but modified by Chat Heads: so at the time of writing,
+	 * @param component The Component in which to look for a head component aka
+	 * {@link PlayerSprite} object. At the time of writing, Chat Heads adds such a head
 	 * after {@link MethodHead} of addMessage(...) but before the
 	 * {@link ChatComponentMixin#modifyMessage(Component, GuiMessageTag)}
 	 * injector is called.
+	 * Servers can add such head as they wish too.
 	 *
 	 * @see <a href="https://github.com/dzwdz/chat_heads/issues/83">ChatHeads#83</a>
 	 * and <a href="https://github.com/mrbuilder1961/ChatPatches/issues/285">#285</a>.
 	 */
-	public static Optional<MutableComponent> extractHeadComponent(Component message) {
-		if(message.getContents() instanceof ObjectContents(PlayerSprite ignored)) {
-			return Optional.of((MutableComponent) message);
+	public static Optional<Component> extractHeadComponent(Component component) {
+		if(component.getContents() instanceof ObjectContents(PlayerSprite ignored)) {
+			return Optional.of(component);
 		}
 
-		if(message.getContents() instanceof TranslatableContents translatable) {
+		if(component.getContents() instanceof TranslatableContents translatable) {
 			for(var arg : translatable.getArgs()) {
 				if(arg instanceof Component c) {
 					var head = extractHeadComponent(c);
@@ -109,7 +108,7 @@ public class ChatHeadsIntegration {
 			}
 		}
 
-		for(var sibling : message.getSiblings()) {
+		for(var sibling : component.getSiblings()) {
 			var head = extractHeadComponent(sibling);
 			if(head.isPresent()) {
 				return head;

--- a/src/main/java/obro1961/chatpatches/util/ChatUtil.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtil.java
@@ -101,7 +101,7 @@ public class ChatUtil {
 	 * however, when factoring in team pre- and
 	 * suf-fixes, this limit becomes irrelevant.
 	 */
-	public static final Matcher VANILLA_FORMAT = Pattern.compile("^((-> )?\\[.+] )?<(\\w{1,16}|\\[(\\w{1,16}) head]\\4)>\\s.+$").matcher("");
+	public static final Matcher VANILLA_FORMAT = Pattern.compile("^((-> )?\\[.+] )?<([^]>]*\\w{1,16}[^]>]*|\\[(\\w{1,16}) head][^]>]*\\4[^]>]*)>\\s.+$").matcher("");
 	public static final Matcher PARSEABLE_MESSAGE_KEYS = Pattern.compile("chat.type.(text|team.(text|sent))").matcher("");
 
 

--- a/src/main/java/obro1961/chatpatches/util/ChatUtil.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtil.java
@@ -4,12 +4,13 @@ import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
-import net.minecraft.util.Util;
 import net.minecraft.client.GuiMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.ChatComponent;
+import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.network.chat.*;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.util.Util;
 import obro1961.chatpatches.Boundary;
 import obro1961.chatpatches.ChatLog;
 import obro1961.chatpatches.ChatPatches;
@@ -28,6 +29,9 @@ import java.util.regex.Pattern;
 
 import static net.minecraft.network.chat.CommonComponents.EMPTY;
 import static obro1961.chatpatches.ChatPatches.*;
+//? if >=1.21.9 {
+import static obro1961.chatpatches.integration.ChatHeadsIntegration.extractHeadComponent;
+//? }
 import static obro1961.chatpatches.util.TextUtil.withoutContent;
 
 public class ChatUtil {
@@ -97,7 +101,7 @@ public class ChatUtil {
 	 * however, when factoring in team pre- and
 	 * suf-fixes, this limit becomes irrelevant.
 	 */
-	public static final Matcher VANILLA_FORMAT = Pattern.compile("(?i)^((-> )?\\[.+] )?<.{3,}>\\s.+$").matcher("");
+	public static final Matcher VANILLA_FORMAT = Pattern.compile("^((-> )?\\[.+] )?<(\\w{1,16}|\\[(\\w{1,16}) head]\\4)>\\s.+$").matcher("");
 	public static final Matcher PARSEABLE_MESSAGE_KEYS = Pattern.compile("chat.type.(text|team.(text|sent))").matcher("");
 
 
@@ -369,8 +373,17 @@ public class ChatUtil {
 			// reconstruct the player message if it's in the vanilla format & it should be reformatted
 			// the messageData vanilla means the original message was vanilla-formatted, and the regex check means it still is.
 			// see Xaero's Minimap waypoint sharing for more information (#158)
-			if(config.name && !lastEmpty && messageData.vanilla && VANILLA_FORMAT.reset(m.getString()).matches()) {
+			Matcher matcher = VANILLA_FORMAT.reset(m.getString());
+			if(config.name && !lastEmpty && messageData.vanilla && matcher.matches()) {
 				content = Component.empty().setStyle(style);
+
+				Optional<Component> head = Optional.empty();
+				//? if >=1.21.9 {
+				// when group 4 (the backreference) exists, "[playername head]playername" was matched
+				if (matcher.group(4) != null) {
+					head = extractHeadComponent(m);
+				}
+				//? }
 
 				// if the message is translatable, then we know exactly where everything is
 				if(m.getContents() instanceof TranslatableContents ttc && PARSEABLE_MESSAGE_KEYS.reset(ttc.getKey()).matches()) {
@@ -390,7 +403,7 @@ public class ChatUtil {
 					content.append(teamPart); // adds the team part or nothing to keep MSG_TEAM_INDEX constant
 
 					// adds the formatted playername and content for all message types
-					content.append( config.formatPlayername(m, messageData.sender) );
+					content.append( config.formatPlayername(head, messageData.sender) );
 					content.append( getArg(ttc, team ? MSG_CONTENT_INDEX : MESSAGE_INDEX) );
 				} else { // reconstructs the message if it matches the vanilla format '<%s> %s' but isn't translatable
 					MutableComponent realContent = Component.empty();
@@ -425,7 +438,7 @@ public class ChatUtil {
 					}
 
 					content.append(EMPTY); // keeps MSG_TEAM_INDEX constant
-					content.append(config.formatPlayername(m, messageData.sender)); // sender data is already known
+					content.append(config.formatPlayername(head, messageData.sender)); // sender data is already known
 					content.append(realContent); // adds the reconstructed message content
 				}
 			}


### PR DESCRIPTION
As mentioned [here](https://github.com/dzwdz/chat_heads/issues/83#issuecomment-3711298017).

Instead of passing the whole message to `formatPlayername()`, only an (optional) head component is passed.

In the translatable case is only searches for a head in the sender part and in the non-translatable case it stops searching for a head once a '>' is found.

I removed the `if(/*ChatHeadsIntegration.*/installed() && usingBeforeName())` check since this is not Chat Heads specific, as servers can add head components in the name part as well.
Technically, `extractHeadComponent()` thus shouldn't really be part of `ChatHeadsIntegration`.
Actually, the whole class can be nuked I just realized, I'll leave that up to you.

I added "chat.type.text" translatable handling to `extractHeadComponent` so it aborts early when it encounters it as well - I don't think it's actually needed but I thought might as well. (Left out the "chat.type.team.*" ones though.)

A bit concerning but I couldn't get the whole [vanilla branch](https://github.com/mrbuilder1961/ChatPatches/blob/404e538d2f55e68e1b67e52ea7c8b676a5a552e9/src/main/java/obro1961/chatpatches/util/ChatUtil.java#L372) to trigger on my test EssentialsX server (even though the chat is of the form `<name> message`). Not sure what's up with that.
Ended up doing some manual tests via code.

P.S.
I feel this could have taken an hour less if it weren't for Modstitch/Stonecutter or whatever the multiversion build thing is, took some time to figure it out. 😅
(`org.gradle.jvmargs=-Xmx2G` is also too little and Gradle ran OOM a few times.)