### PR TITLE
Fix `tryCondenseDupes(.)` crashing when `visibles` is empty (IOOBE)

### DIFF
--- a/src/main/java/obro1961/chatpatches/util/ChatUtil.java
+++ b/src/main/java/obro1961/chatpatches/util/ChatUtil.java
@@ -665,8 +665,10 @@ public class ChatUtil {
 			dupeCount += Integers.parseInt( getPart(msg, DUPE_INDEX).getString().replaceAll("(§\\d)|\\D", "") , 1);
 
 			int v = config.compactChat ? message2Visible(i) : i; // ensure that `i` correctly maps to its EoE visible
-			do visibles.remove(v); // remove the visible message(s) of the message being condensed, starting with its own EoE
-			while(v < visibles.size() && !visibles.get(v).endOfEntry()); // continue removing them until the next message (EoE) is reached
+			if ( !visibles.isEmpty() ) {
+				do visibles.remove(v); // remove the visible message(s) of the message being condensed, starting with its own EoE
+				while (v < visibles.size() && !visibles.get(v).endOfEntry()); // continue removing them until the next message (EoE) is reached
+			}
 
 			// remove the message being condensed; done last to ensure #message2Visible(.) works correctly
 			messages.remove(i);


### PR DESCRIPTION
Intends to fix a network protocol error.
visibilities index 0 is removed, although the list might be empty (I guess it usually is not empty, but looks like that's not always the case, haven't looked that deeply into it)
A very censored version of the disconnect report (not from me I'm unable to reproduce, hit me up if you for some reason need the uncensored report): https://mclo.gs/6CDu1Bq